### PR TITLE
fix(mapping): correct SMO objects mapping to prevent 'smo' key addition

### DIFF
--- a/src/openstix/mappings/base.py
+++ b/src/openstix/mappings/base.py
@@ -16,8 +16,8 @@ def load_objects_mappings(module):
 
         object_class = getattr(module, object_class_name)
 
-        if object_class_name in ["GranularMarking", "LanguageContent", "StatementMarking", "TLPMarking"]:
-            SMOS_MAPPING[object_class_name] = object_class
+        if object_class_name in ["MarkingDefinition", "LanguageContent", "StatementMarking", "TLPMarking"]:
+            SMOS_MAPPING[object_class._type] = object_class
             continue
 
         mapping_type = get_object_type(object_class._type)

--- a/src/openstix/mappings/base.py
+++ b/src/openstix/mappings/base.py
@@ -1,7 +1,6 @@
 from openstix import extensions, objects
 from openstix.utils import get_object_type
 
-
 STIX_OBJECTS_MAPPING = {}
 STIX_OBJECTS_EXTENSIONS_MAPPING = {}
 SCOS_MAPPING = {}
@@ -18,7 +17,7 @@ def load_objects_mappings(module):
         object_class = getattr(module, object_class_name)
 
         if object_class_name in ["GranularMarking", "LanguageContent", "StatementMarking", "TLPMarking"]:
-            SMOS_MAPPING["smo"] = object_class
+            SMOS_MAPPING[object_class_name] = object_class
             continue
 
         mapping_type = get_object_type(object_class._type)

--- a/src/openstix/objects/__init__.py
+++ b/src/openstix/objects/__init__.py
@@ -1,7 +1,7 @@
 from stix2.v21.bundle import Bundle
 from stix2.v21.common import (
-    GranularMarking,
     LanguageContent,
+    MarkingDefinition,
     StatementMarking,
     TLPMarking,
 )

--- a/src/openstix/toolkit/workspace.py
+++ b/src/openstix/toolkit/workspace.py
@@ -51,7 +51,7 @@ class Workspace(Environment):
         self.add(obj)
         return obj
 
-    def query(self, query=[], last_version_only=True):
+    def query(self, query=None, last_version_only=True):
         """Executes a query against the store to retrieve STIX objects.
 
         Args:
@@ -65,6 +65,9 @@ class Workspace(Environment):
             List[stix2.base._STIXBase]: A list of STIX objects that match the query criteria. When `last_version_only`
                                         is True, the list will contain only the most recent version of each object.
         """
+        if query is None:
+            query = []
+
         all_objects = super().query(query)
         if not last_version_only or not all_objects:
             return all_objects


### PR DESCRIPTION
```
defaultvscode ➜ /openstix-python (feature/carav-810) $ python
Python 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import openstix
>>> object_types = openstix.mappings.STIX_OBJECTS_MAPPING.keys()
>>> print(object_types)
dict_keys([
    'artifact', 
    'autonomous-system', 
    'directory', 
    'domain-name', 
    'email-addr', 
    'email-message', 
    'file', 
    'ipv4-addr', 
    'ipv6-addr', 
    'mac-addr', 
    'mutex', 
    'network-traffic', 
    'process', 
    'software', 
    'url', 
    'user-account', 
    'windows-registry-key', 
    'x509-certificate', 
    'attack-pattern', 
    'campaign', 
    'course-of-action', 
    'grouping', 
    'identity', 
    'incident', 
    'indicator', 
    'infrastructure', 
    'intrusion-set', 
    'location', 
    'malware', 
    'malware-analysis', 
    'note', 
    'observed-data', 
    'opinion', 
    'report', 
    'threat-actor', 
    'tool', 
    'vulnerability', 
    'x-mitre-asset', 
    'x-mitre-data-component', 
    'x-mitre-data-source', 
    'x-mitre-matrix', 
    'x-mitre-tactic', 
    'relationship', 
    'sighting', 
    'GranularMarking', 
    'LanguageContent', 
    'StatementMarking', 
    'TLPMarking'
])
```