### PR TITLE
chore: bump pypa/gh-action-pypi-publish to v1.12.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
           path: dist
 
       - name: Publish package distributions
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.3


### PR DESCRIPTION
According to [this comment](https://github.com/pypi/warehouse/issues/15611#issuecomment-2198363695) our release error might be due to hatchling using a core metadata format that twine does not support. In the [latest release changelog](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.3) for the `pypa/gh-action-pypi-publish` action the maintainers say:

> it is now possible to publish [distribution packages](https://packaging.python.org/en/latest/glossary/#term-Distribution-Package) that include [core metadata v2.4](https://packaging.python.org/en/latest/specifications/core-metadata/#metadata-version)

So this might do the trick.